### PR TITLE
Added support for silent mode.

### DIFF
--- a/src/pg_embedded_clj/core.clj
+++ b/src/pg_embedded_clj/core.clj
@@ -2,9 +2,7 @@
   (:require [clojure.pprint :as pprint]
             [clojure.tools.logging :as log]
             [integrant.core :as ig]
-            [pg-embedded-clj.state :as state]
-            [clojure.java.io :as io])
-  (:import com.opentable.db.postgres.embedded.EmbeddedPostgres))
+            [pg-embedded-clj.state :as state]))
 
 (def default-config
   {:port         5432
@@ -12,7 +10,8 @@
 
 (defn ->ig-config [config]
   {:pg-embedded-clj.postgres/postgres {:port (:port config)
-                                       :log-redirect (:log-redirect config)}})
+                                       :log-redirect (:log-redirect config)
+                                       :silent? (:silent? config)}})
 
 (defn halt-pg! []
   (when @state/state

--- a/src/pg_embedded_clj/postgres.clj
+++ b/src/pg_embedded_clj/postgres.clj
@@ -4,21 +4,24 @@
   (:import com.opentable.db.postgres.embedded.EmbeddedPostgres
            java.lang.ProcessBuilder$Redirect))
 
-(defn ->pg [port pg-log]
+(defn ->pg [port pg-log silent?]
   (let [pg (-> (EmbeddedPostgres/builder)
                (.setPort port))]
     (when pg-log (let [log-redirector (ProcessBuilder$Redirect/appendTo (io/file pg-log))]
-                 (-> pg
-                     (.setOutputRedirector log-redirector)
-                     (.setErrorRedirector log-redirector))))
+                   (-> pg
+                       (.setOutputRedirector log-redirector)
+                       (.setErrorRedirector log-redirector))))
+    (when silent?
+      (.setConnectConfig pg "-s" ""))
+
     (.start pg)))
 
 (defn halt! [pg]
   (when pg
     (.close pg)))
 
-(defmethod ig/init-key ::postgres [_ {:keys [port log-redirect]}]
-  (->pg port log-redirect))
+(defmethod ig/init-key ::postgres [_ {:keys [port log-redirect silent?]}]
+  (->pg port log-redirect silent?))
 
 (defmethod ig/halt-key! ::postgres [_ pg]
   (halt! pg))


### PR DESCRIPTION
Leverage the support in opentable embedded postgress for "connect args" - i.e. switches directly into `pg_ctl` to add the `-s` (silent mode) switch.