### PR TITLE
bump: Update dependencies and adds gh-action test

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,40 @@
+name: Tests
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+
+  tests:
+
+    strategy:
+      matrix:
+        operating-system: [ubuntu-latest]
+
+    runs-on: ${{ matrix.operating-system }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Prepare java
+        uses: actions/setup-java@v2.5.0
+        with:
+          distribution: 'adopt'
+          java-version: '11'
+
+      - name: Install clojure tools-deps
+        uses: DeLaGuardo/setup-clojure@master
+        with:
+          lein: 2.9.8
+
+      - name: Execute clojure code
+        run: lein test

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ profiles.clj
 *.iml
 *.log
 resources/
+.lsp/.cache
+.clj-kondo/.cache

--- a/project.clj
+++ b/project.clj
@@ -1,13 +1,13 @@
-(defproject bigsy/pg-embedded-clj "0.1.0"
+(defproject bigsy/pg-embedded-clj "0.2.0"
   :description "Embedded postgres for clojure"
   :url "https://github.com/Bigsy/pg-embedded-clj"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.10.2"]
+  :dependencies [[org.clojure/clojure "1.10.3"]
                  [integrant "0.8.0"]
-                 [org.clojure/tools.logging "1.1.0"]
-                 [org.clojure/tools.namespace "1.1.0"]
-                 [io.zonky.test/embedded-postgres "1.2.10"]
-                 [org.slf4j/slf4j-jdk14 "1.7.30"]]
+                 [org.clojure/tools.logging "1.2.4"]
+                 [org.clojure/tools.namespace "1.2.0"]
+                 [io.zonky.test/embedded-postgres "1.3.1"]
+                 [org.slf4j/slf4j-jdk14 "1.7.35"]]
 
   :profiles {:dev {:dependencies [[org.clojure/java.jdbc "0.7.12"]]}})

--- a/test/pg_embedded_clj/custom_test.clj
+++ b/test/pg_embedded_clj/custom_test.clj
@@ -1,8 +1,8 @@
 (ns pg-embedded-clj.custom-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.java.io :as io]
             [clojure.java.jdbc :as jdbc]
-            [pg-embedded-clj.core :as sut]
-            [clojure.java.io :as io]))
+            [clojure.test :refer [deftest is testing use-fixtures]]
+            [pg-embedded-clj.core :as sut]))
 
 (use-fixtures :once sut/with-pg-fn)
 
@@ -18,14 +18,14 @@
 (def db-spec {:classname   "org.postgresql.Driver"
               :subprotocol "postgresql"
               :subname     (str
-                             "//localhost:"
-                             54321
-                             "/postgres")
+                            "//localhost:"
+                            54321
+                            "/postgres")
               :user        "postgres"})
 (deftest can-wrap-around
   (testing "using custom port"
-      (is (= {:version "PostgreSQL 10.15 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 4.4.7 20120313 (Red Hat 4.4.7-23), 64-bit"}
-             (first (jdbc/query db-spec ["select version()"])))))
+    (is (= {:version "PostgreSQL 10.18 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 4.4.7 20120313 (Red Hat 4.4.7-23), 64-bit"}
+           (first (jdbc/query db-spec ["select version()"])))))
 
   (testing "using custom log redirect"
     (is (= true (.exists (io/as-file "wibble.log"))))))

--- a/test/pg_embedded_clj/default_test.clj
+++ b/test/pg_embedded_clj/default_test.clj
@@ -1,6 +1,6 @@
 (ns pg-embedded-clj.default-test
-  (:require [clojure.test :refer :all]
-            [clojure.java.jdbc :as jdbc]
+  (:require [clojure.java.jdbc :as jdbc]
+            [clojure.test :refer [deftest is testing use-fixtures]]
             [pg-embedded-clj.core :as sut]))
 
 (use-fixtures :once sut/with-pg-fn)
@@ -20,5 +20,5 @@
               :user        "postgres"})
 (deftest can-wrap-around
   (testing "using defaults"
-      (is (= {:version "PostgreSQL 10.15 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 4.4.7 20120313 (Red Hat 4.4.7-23), 64-bit"}
+      (is (= {:version "PostgreSQL 10.18 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 4.4.7 20120313 (Red Hat 4.4.7-23), 64-bit"}
              (first (jdbc/query db-spec ["select version()"]))))))


### PR DESCRIPTION
I bumped the dependencies of you project, because the new version of io.zonky.test/embedded-postgres added some nice features:
- Upgrade to PostgreSQL 10.18 ([#71](https://github.com/zonkyio/embedded-postgres/issues/71))
- Upgrade to Apache Commons Compress 1.21 ([#69](https://github.com/zonkyio/embedded-postgres/issues/69))
- Support for Rosetta 2 emulation on Macs with Apple Silicon (M1) ([#52](https://github.com/zonkyio/embedded-postgres/issues/52))
- Upgrade to Flyway 7 ([#46](https://github.com/zonkyio/embedded-postgres/issues/46))

I also added an Github Actions CI to automatically check the tests on PR and merges on Master.