### PR TITLE
Fix README indentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ To use a specific PostgreSQL version or architecture, include an additional depe
 
 ;; Start PostgreSQL with custom configuration
 (init-pg {:port 5433
-         :log-redirect "postgres.log"})
+          :log-redirect "postgres.log"})
 
 ;; Stop the PostgreSQL instance
 (halt-pg!)


### PR DESCRIPTION
Using this library for some Clojure Postgres tests and noticed the indentation was off for the examples