### PR TITLE
Upgrade from deprecated java.jdbc to next.jdbc

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,4 +10,4 @@
                  [org.clojure/tools.namespace "1.5.0"]]
 
 
-  :profiles {:dev {:dependencies [[org.clojure/java.jdbc "0.7.12"]]}})
+  :profiles {:dev {:dependencies [[com.github.seancorfield/next.jdbc "1.3.939"]]}})

--- a/test/pg_embedded_clj/custom_test.clj
+++ b/test/pg_embedded_clj/custom_test.clj
@@ -1,6 +1,6 @@
 (ns pg-embedded-clj.custom-test
   (:require [clojure.java.io :as io]
-            [clojure.java.jdbc :as jdbc]
+            [next.jdbc :as jdbc]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [pg-embedded-clj.core :as sut]))
 
@@ -15,13 +15,7 @@
 
 (use-fixtures :once around-all)
 
-(def db-spec {:classname   "org.postgresql.Driver"
-              :subprotocol "postgresql"
-              :subname     (str
-                            "//localhost:"
-                            54321
-                            "/postgres")
-              :user        "postgres"})
+(def db-spec (str "jdbc:postgresql://localhost:" 54321 "/postgres?user=postgres"))
 
 (defn extract-postgres-version [input]
   (if input
@@ -32,8 +26,7 @@
 
 (deftest can-wrap-around
   (testing "using custom port"
-    (is (= (some-> (jdbc/query db-spec ["select version()"])
-                   first
+    (is (= (some-> (jdbc/execute-one! db-spec ["select version()"])
                    :version
                    extract-postgres-version)
            "14.10")))

--- a/test/pg_embedded_clj/default_test.clj
+++ b/test/pg_embedded_clj/default_test.clj
@@ -1,5 +1,5 @@
 (ns pg-embedded-clj.default-test
-  (:require [clojure.java.jdbc :as jdbc]
+  (:require [next.jdbc :as jdbc]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [pg-embedded-clj.core :as sut]))
 
@@ -11,13 +11,7 @@
 
 (use-fixtures :once around-all)
 
-(def db-spec {:classname   "org.postgresql.Driver"
-              :subprotocol "postgresql"
-              :subname     (str
-                             "//localhost:"
-                             5432
-                             "/postgres")
-              :user        "postgres"})
+(def db-spec (str "jdbc:postgresql://localhost:" 5432 "/postgres?user=postgres"))
 
 (defn extract-postgres-version [input]
   (if input
@@ -28,8 +22,7 @@
 
 (deftest can-wrap-around
   (testing "using defaults"
-    (is (= (some-> (jdbc/query db-spec ["select version()"])
-                   first
+    (is (= (some-> (jdbc/execute-one! db-spec ["select version()"])
                    :version
                    extract-postgres-version)
            "14.10"))))


### PR DESCRIPTION
This PR upgrades the project from the deprecated `org.clojure/java.jdbc` to the modern `next.jdbc` library.

## Changes
- Replace `org.clojure/java.jdbc` with `com.github.seancorfield/next.jdbc 1.3.939`
- Update test namespaces to use `next.jdbc`
- Convert db-spec from map format to JDBC URL string format
- Replace `jdbc/query` with `jdbc/execute-one!` for cleaner single-row queries
- Remove need for `first` since `execute-one!` returns single row directly

## Benefits
- Resolves deprecation warning
- Modernizes database access patterns
- Better performance and active maintenance
- Cleaner, more idiomatic code

Closes #6

Generated with [Claude Code](https://claude.ai/code)